### PR TITLE
rake missing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    xcodesnippets (0.2.0)
+    xcodesnippets (0.2.1)
       clamp (~> 0.2.1)
       highline (~> 1.6.2)
       plist (~> 3.1.0)
@@ -28,6 +28,7 @@ GEM
     linecache19 (0.5.12)
       ruby_core_source (>= 0.1.4)
     plist (3.1.0)
+    rake (0.9.2)
     rspec (2.6.0)
       rspec-core (~> 2.6.0)
       rspec-expectations (~> 2.6.0)
@@ -53,7 +54,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  clamp (~> 0.2.1)
   cucumber
+  highline (~> 1.6.2)
+  plist (~> 3.1.0)
+  rake
   rspec
   ruby-debug19
+  uuidtools (~> 2.1.2)
   xcodesnippets!

--- a/xcodesnippets.gemspec
+++ b/xcodesnippets.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<cucumber>, [">= 0"])
       s.add_development_dependency(%q<ruby-debug19>, [">= 0"])
+      s.add_development_dependency(%q<rake>, [">= 0"])
     else
       s.add_dependency(%q<clamp>, ["~> 0.2.1"])
       s.add_dependency(%q<uuidtools>, ["~> 2.1.2"])
@@ -37,6 +38,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<rspec>, [">= 0"])
       s.add_dependency(%q<cucumber>, [">= 0"])
       s.add_dependency(%q<ruby-debug19>, [">= 0"])
+      s.add_dependency(%q<rake>, [">= 0"])
     end
   else
     s.add_dependency(%q<clamp>, ["~> 0.2.1"])
@@ -46,5 +48,6 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<rspec>, [">= 0"])
     s.add_dependency(%q<cucumber>, [">= 0"])
     s.add_dependency(%q<ruby-debug19>, [">= 0"])
+    s.add_dependency(%q<rake>, [">= 0"])
   end
 end


### PR DESCRIPTION
Adding rake (>0) to Gemspec dependencies to let ContinuityApp successfully run tests
